### PR TITLE
fix typo

### DIFF
--- a/Examples/CAN/communication_Loopback/main.c
+++ b/Examples/CAN/communication_Loopback/main.c
@@ -114,7 +114,7 @@ int main(void)
 */
 ErrStatus can_loopback(void)
 {
-    can_trasnmit_message_struct transmit_message;
+    can_transmit_message_struct transmit_message;
     can_receive_message_struct  receive_message;
     uint32_t timeout = 0xFFFF;
     uint8_t transmit_mailbox = 0;
@@ -170,7 +170,7 @@ ErrStatus can_loopback(void)
 */
 ErrStatus can_loopback_interrupt(void)
 {
-    can_trasnmit_message_struct transmit_message;
+    can_transmit_message_struct transmit_message;
     uint32_t timeout = 0x0000FFFF;
     
     /* initialize CAN and filter */

--- a/Examples/CAN/communication_among_CANs/main.c
+++ b/Examples/CAN/communication_among_CANs/main.c
@@ -58,7 +58,7 @@ FlagStatus can0_error_flag;
 FlagStatus can1_error_flag;
 can_parameter_struct can_init_parameter;
 can_filter_parameter_struct can_filter_parameter;
-can_trasnmit_message_struct transmit_message;
+can_transmit_message_struct transmit_message;
 can_receive_message_struct receive_message;
 
 void clic_config(void);

--- a/Examples/CAN/communication_among_Devices/main.c
+++ b/Examples/CAN/communication_among_Devices/main.c
@@ -50,7 +50,7 @@ OF SUCH DAMAGE.
 FlagStatus receive_flag;
 uint8_t transmit_number = 0x0;
 can_receive_message_struct receive_message;
-can_trasnmit_message_struct transmit_message;
+can_transmit_message_struct transmit_message;
     
 void clic_config(void);
 void led_config(void);

--- a/Firmware/GD32VF103_standard_peripheral/Include/gd32vf103_can.h
+++ b/Firmware/GD32VF103_standard_peripheral/Include/gd32vf103_can.h
@@ -386,7 +386,7 @@ typedef struct {
 	uint8_t tx_ft; /*!< type of frame, data or remote */
 	uint8_t tx_dlen; /*!< data length */
 	uint8_t tx_data[8]; /*!< transmit data */
-} can_trasnmit_message_struct;
+} can_transmit_message_struct;
 
 /* CAN receive message struct */
 typedef struct {
@@ -675,7 +675,7 @@ void can_time_trigger_mode_disable(uint32_t can_periph);
 /* transmit functions */
 /* transmit CAN message */
 uint8_t can_message_transmit(uint32_t can_periph,
-		can_trasnmit_message_struct* transmit_message);
+		can_transmit_message_struct* transmit_message);
 /* get CAN transmit state */
 can_transmit_state_enum can_transmit_states(uint32_t can_periph,
 		uint8_t mailbox_number);

--- a/Firmware/GD32VF103_standard_peripheral/Source/gd32vf103_can.c
+++ b/Firmware/GD32VF103_standard_peripheral/Source/gd32vf103_can.c
@@ -103,14 +103,14 @@ void can_struct_para_init(can_struct_type_enum type, void* p_struct)
         /* used for can_message_transmit() */
         case CAN_TX_MESSAGE_STRUCT:
             for(i = 0U; i < 8U; i++){
-                ((can_trasnmit_message_struct*)p_struct)->tx_data[i] = 0U;
+                ((can_transmit_message_struct*)p_struct)->tx_data[i] = 0U;
             }
             
-            ((can_trasnmit_message_struct*)p_struct)->tx_dlen = 0u;
-            ((can_trasnmit_message_struct*)p_struct)->tx_efid = 0U;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_trasnmit_message_struct*)p_struct)->tx_sfid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_dlen = 0u;
+            ((can_transmit_message_struct*)p_struct)->tx_efid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+            ((can_transmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+            ((can_transmit_message_struct*)p_struct)->tx_sfid = 0U;
             
             break;
         /* used for can_message_receive() */
@@ -427,7 +427,7 @@ void can_time_trigger_mode_disable(uint32_t can_periph)
     \param[out] none
     \retval     mailbox_number
 */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message)
+uint8_t can_message_transmit(uint32_t can_periph, can_transmit_message_struct* transmit_message)
 {
     uint8_t mailbox_number = CAN_MAILBOX0;
 


### PR DESCRIPTION
Fix the typo of `can_trasnmit_message_struct` -> `can_transmit_message_struct` in CAN-related files.